### PR TITLE
Change the remote to release because Travis does not find the master remote

### DIFF
--- a/changelog.json
+++ b/changelog.json
@@ -3,7 +3,7 @@
 
  "fromRepo": ".",
  "fromCommit": "0000000000000000000000000000000000000000",
- "toRef": "refs/remotes/origin/master",
+ "toRef": "refs/remotes/origin/release",
  
  "ignoreCommitsIfMessageMatches": "^\\[maven-release-plugin\\].*|^\\[Gradle Release Plugin\\].*",
  "dateFormat": "YYYY-MM-dd HH:mm:ss",


### PR DESCRIPTION
Closes #7 Travis clone the project but the reference to master is missing. Thus the changelog.json file is modified to point to release remote.